### PR TITLE
Add flow to create a new chess game

### DIFF
--- a/clients/build.gradle
+++ b/clients/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-websocket:$spring_boot_version") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
     }
+// https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.9.7'
 
     compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     compile "org.apache.logging.log4j:log4j-web:${log4j_version}"

--- a/clients/src/main/kotlin/com/lightningchess/webserver/Controller.kt
+++ b/clients/src/main/kotlin/com/lightningchess/webserver/Controller.kt
@@ -15,7 +15,7 @@ import java.util.*
 /**
  * Define your API endpoints here.
  */
-val SERVICE_NAMES = listOf("Network Map Service")
+val SERVICE_NAMES = listOf("Notary", "Network Map Service")
 
 @RestController
 @CrossOrigin

--- a/clients/src/main/kotlin/com/lightningchess/webserver/Controller.kt
+++ b/clients/src/main/kotlin/com/lightningchess/webserver/Controller.kt
@@ -1,10 +1,16 @@
 package com.lightningchess.webserver
 
+import com.lightningchess.flow.CreateGameFlow.Initiator
+import com.lightningchess.state.GameState
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.messaging.startTrackedFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.utilities.getOrThrow
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URI
+import java.util.*
 
 /**
  * Define your API endpoints here.
@@ -39,19 +45,31 @@ class Controller(rpc: NodeRPCConnection) {
                 .filter { it.organisation !in (SERVICE_NAMES + myLegalName.organisation) })
     }
 
+    /**
+     * Creates a new game by providing the opponent's X500 name. If the opponent (node) is up and running and sign the
+     * contract, then the game will be considered as started.
+     */
     @PostMapping(value = "/create-game", produces = arrayOf("application/json"))
-    fun createGame(@RequestBody gameRequest: NewGameRequest): ResponseEntity<NewGameRequest> {
+    fun createGame(@RequestBody gameRequest: NewGameRequest): ResponseEntity<CreateGameResponse> {
         print(gameRequest)
 
+        val opponent = proxy.wellKnownPartyFromX500Name(gameRequest.opponentX500Name) ?:
+        return ResponseEntity.badRequest().build()
+
         return try {
-            //val signedTx = proxy.startTrackedFlow(::IssueJournalStateFlow, ).returnValue.getOrThrow()
+            val signedTx = proxy.startTrackedFlow(::Initiator, gameRequest.userNickname, opponent).returnValue.getOrThrow()
 
-            //"Transaction id ${signedTx.id}
-
-            return ResponseEntity.created(URI("")).body(gameRequest)
+            return ResponseEntity.created(URI(""))
+                    .body(CreateGameResponse(signedTx.id.toString(), retrieveGameId(signedTx)))
         } catch (ex: Throwable) {
             logger.error(ex.message, ex)
             return ResponseEntity.badRequest().build()
         }
+    }
+
+    private fun retrieveGameId(signedTx: SignedTransaction): UUID {
+        val gameState = signedTx.coreTransaction.outputsOfType<GameState>().first()
+
+        return gameState.gameId
     }
 }

--- a/clients/src/main/kotlin/com/lightningchess/webserver/CreateGameResponse.kt
+++ b/clients/src/main/kotlin/com/lightningchess/webserver/CreateGameResponse.kt
@@ -1,0 +1,10 @@
+package com.lightningchess.webserver
+
+import java.util.*
+
+data class CreateGameResponse(
+        val transactionId: String,
+        val gameId: UUID
+) {
+
+}

--- a/clients/src/main/kotlin/com/lightningchess/webserver/NewGameRequest.kt
+++ b/clients/src/main/kotlin/com/lightningchess/webserver/NewGameRequest.kt
@@ -1,9 +1,10 @@
 package com.lightningchess.webserver
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import net.corda.core.identity.CordaX500Name
 
 data class NewGameRequest @JsonCreator constructor(
-    val opponentX500Name: String,
-    val userNickname: String) {
+        val opponentX500Name: CordaX500Name,
+        val userNickname: String) {
 
 }

--- a/clients/src/main/resources/static/css/main.css
+++ b/clients/src/main/resources/static/css/main.css
@@ -1,0 +1,4 @@
+label.center {
+    width: 100%;
+    text-align: center;
+}

--- a/clients/src/main/resources/static/index.html
+++ b/clients/src/main/resources/static/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Lightning Chess CorDapp</title>
     <link rel="stylesheet" href="css/chessboard-0.3.0.css">
+    <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
           integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"

--- a/clients/src/main/resources/static/js/main.js
+++ b/clients/src/main/resources/static/js/main.js
@@ -12,7 +12,8 @@ $(document).ready(function() {
 
     var apiBaseURL = "http://localhost:10015/api/";
     var peers = new Array();
-    var myName;
+    var myName, me;
+    var meX500;
 
     $('#createGameModal').modal({show: false});
     $('#messagePopup').modal({show: false});
@@ -23,7 +24,7 @@ $(document).ready(function() {
 
         $.each(peers, function(i, item) {
             $("#opponents").append($('<option>', {
-                value: item.x500Principal.name,
+                value: JSON.stringify(item),
                 text: item.x500Principal.name
             }));
         });
@@ -38,7 +39,7 @@ $(document).ready(function() {
     $("#modalCreateGameBtn").click(function() {
         $("#createGameErrorAlert .alertText").html("");
 
-        var opponentX500Name = $("#opponents").val();
+        var opponentX500Name = JSON.parse($("#opponents").val());
         var nickname = $("#nickname").val();
 
         var createGameEndpoint = apiBaseURL + "create-game";
@@ -55,7 +56,7 @@ $(document).ready(function() {
                 console.log(data);
 
                 $("#myNickname").html(myName + " (" + nickname + ")");
-                $("#opponentNickname").html(opponentX500Name);
+                $("#opponentNickname").html(opponentX500Name.x500Principal.name);
 
                 $("#createGameModal").modal('hide');
 
@@ -69,6 +70,8 @@ $(document).ready(function() {
 
                 //Set user's status message
                 printUserMessage(USER_MESSAGE_STATE_USER_TURN);
+
+                appendToSignaturesConsole("New game started. Signed tx id: " + data.transactionId);
             },
             error: function(data) {
                 createGamePopupErrorAlert.find(".alertText").html(JSON.stringify(data));
@@ -102,7 +105,8 @@ $(document).ready(function() {
 
     var retrieveNickname = function() {
         $.get(apiBaseURL + "me", function(data) {
-            myName = data.me.x500Principal.name;
+            me = data.me
+            myName = me.x500Principal.name;
 
             $("#myNickname").html(myName);
         });
@@ -118,7 +122,7 @@ $(document).ready(function() {
     var appendToSignaturesConsole = function(signature) {
         signaturesConsole.prepend($('<option>', {
                         value: signature,
-                        text: new Date() + " - " + signature
+                        text: new Date().toUTCString() + " - " + signature
                     }));
     }
 

--- a/clients/src/main/resources/static/js/main.js
+++ b/clients/src/main/resources/static/js/main.js
@@ -60,7 +60,10 @@ $(document).ready(function() {
 
                 $("#createGameModal").modal('hide');
 
-                messagePopup.find(".text").html(JSON.stringify(data));
+                messagePopup.find(".text")
+                            .addClass("center")
+                            .html('<h4>Game created successfully!</h4><br/>Game ID: ' + data.gameId);
+
                 messagePopup.modal('show');
 
                 signaturesConsole.find("option").remove();

--- a/cordapp-contracts-states/src/main/kotlin/com/lightningchess/contract/GameContract.kt
+++ b/cordapp-contracts-states/src/main/kotlin/com/lightningchess/contract/GameContract.kt
@@ -1,0 +1,51 @@
+package com.lightningchess.contract
+
+import com.lightningchess.state.GameState
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.contracts.requireSingleCommand
+import net.corda.core.contracts.requireThat
+import net.corda.core.transactions.LedgerTransaction
+
+open class GameContract : Contract {
+    companion object {
+        @JvmStatic
+        val GAME_CONTRACT_ID = "com.lightningchess.contract.GameContract"
+    }
+
+    /**
+     * The verify() function of all the states' contracts must not throw an exception for a transaction to be
+     * considered valid.
+     */
+    override fun verify(tx: LedgerTransaction) {
+        val inputStates = tx.inputStates
+        val outputGameStates = tx.outputsOfType<GameState>()
+
+        val command = tx.commands.requireSingleCommand<Commands>()
+
+        when(command.value) {
+
+            //Create a new game
+            is Commands.Create -> {
+
+                requireThat {
+                    "No inputs should be consumed when creating a new game." using (tx.inputs.isEmpty())
+                    "Only one output state should be created." using (tx.outputs.size == 1)
+                }
+
+            }
+
+            //A game is finished
+            is Commands.Finish -> {
+
+            }
+
+            else -> throw IllegalArgumentException("Unrecognised command")
+        }
+    }
+
+    interface Commands : CommandData {
+        class Create : Commands
+        class Finish: Commands
+    }
+}

--- a/cordapp-contracts-states/src/main/kotlin/com/lightningchess/schema/GameSchemaV1.kt
+++ b/cordapp-contracts-states/src/main/kotlin/com/lightningchess/schema/GameSchemaV1.kt
@@ -1,0 +1,37 @@
+package com.lightningchess.schema
+
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+
+/**
+ * The family of schemas for GameState.
+ */
+object GameSchema
+
+/**
+ * A GameState schema.
+ */
+object GameSchemaV1 : MappedSchema(
+        schemaFamily = GameSchema.javaClass,
+        version = 1,
+        mappedTypes = listOf(PersistentGame::class.java)) {
+    @Entity
+    @Table(name = "game_states")
+    class PersistentGame(
+            @Column(name = "gameId")
+            var gameId: UUID,
+
+            @Column(name = "player_a_nickname")
+            var playerANickname: String,
+
+            @Column(name = "linear_id")
+            var linearId: UUID
+    ) : PersistentState() {
+        // Default constructor required by hibernate.
+        constructor(): this(UUID.randomUUID(), "", UUID.randomUUID())
+    }
+}

--- a/cordapp-contracts-states/src/main/kotlin/com/lightningchess/state/GameState.kt
+++ b/cordapp-contracts-states/src/main/kotlin/com/lightningchess/state/GameState.kt
@@ -1,0 +1,35 @@
+package com.lightningchess.state
+
+import com.lightningchess.schema.GameSchemaV1
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.schemas.MappedSchema
+import net.corda.core.schemas.PersistentState
+import net.corda.core.schemas.QueryableState
+import java.util.*
+
+data class GameState(val gameId: UUID,
+                        val playerANickname: String,
+                        val playerA: Party,
+                        val playerB: Party,
+                        override val linearId: UniqueIdentifier = UniqueIdentifier()):
+        LinearState, QueryableState {
+
+    /** The public keys of the involved parties. */
+    override val participants: List<AbstractParty> get() = setOf(playerA, playerB).toList()
+
+    override fun generateMappedObject(schema: MappedSchema): PersistentState {
+        return when (schema) {
+            is GameSchemaV1 -> GameSchemaV1.PersistentGame(
+                    UUID.randomUUID(),
+                    playerANickname,
+                    this.linearId.id
+            )
+            else -> throw IllegalArgumentException("Unrecognised schema $schema")
+        }
+    }
+
+    override fun supportedSchemas(): Iterable<MappedSchema> = listOf(GameSchemaV1)
+}

--- a/cordapp/src/main/kotlin/com/lightningchess/flow/CreateGameFlow.kt
+++ b/cordapp/src/main/kotlin/com/lightningchess/flow/CreateGameFlow.kt
@@ -60,7 +60,7 @@ object CreateGameFlow {
             val session = initiateFlow(opponent)
 
             //Creating the output state
-            var gameState = GameState(UUID.randomUUID(), playerANickname, me, opponent)
+            val gameState = GameState(UUID.randomUUID(), playerANickname, me, opponent)
 
             val txCommand = Command(GameContract.Commands.Create(), gameState.participants.map { it.owningKey })
             val txBuilder = TransactionBuilder(notary)

--- a/cordapp/src/main/kotlin/com/lightningchess/flow/CreateGameFlow.kt
+++ b/cordapp/src/main/kotlin/com/lightningchess/flow/CreateGameFlow.kt
@@ -1,0 +1,111 @@
+package com.lightningchess.flow
+
+import co.paralleluniverse.fibers.Suspendable
+import com.lightningchess.contract.GameContract
+import com.lightningchess.state.GameState
+import net.corda.core.contracts.Command
+import net.corda.core.contracts.requireThat
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+import java.util.*
+
+/**
+ * This flow is executed when an entity (player) initiates a new game against another entity of the network (opponent)
+ */
+object CreateGameFlow {
+
+    @StartableByRPC
+    @InitiatingFlow
+    class Initiator(var playerANickname: String,
+                    val opponent: Party) : FlowLogic<SignedTransaction>() {
+        /**
+         * The progress tracker checkpoints each stage of the flow and outputs the specified messages when each
+         * checkpoint is reached in the code. See the 'progressTracker.currentStep' expressions within the call() function.
+         */
+        companion object {
+            object GENERATING_TRANSACTION : ProgressTracker.Step("Generating transaction.")
+            object SIGNING_TRANSACTION : ProgressTracker.Step("Signing transaction with our private key.")
+            object GATHERING_SIGS : ProgressTracker.Step("Gathering the counterparty's signature.") {
+                override fun childProgressTracker() = CollectSignaturesFlow.tracker()
+            }
+            object FINALISING_TRANSACTION : ProgressTracker.Step("Obtaining notary signature and recording transaction.") {
+                override fun childProgressTracker() = FinalityFlow.tracker()
+            }
+
+            fun tracker() = ProgressTracker(
+                    GENERATING_TRANSACTION,
+                    SIGNING_TRANSACTION,
+                    GATHERING_SIGS,
+                    FINALISING_TRANSACTION
+            )
+        }
+
+        override val progressTracker = tracker()
+
+        /**
+         * The flow logic is encapsulated within the call() method.
+         */
+        @Suspendable
+        override fun call(): SignedTransaction {
+            // Obtain a reference to the notary we want to use.
+            val notary = serviceHub.networkMapCache.notaryIdentities[0]
+            val me = serviceHub.myInfo.legalIdentities.single()
+
+            // Stage 1.
+            progressTracker.currentStep = GENERATING_TRANSACTION
+
+            val session = initiateFlow(opponent)
+
+            //Creating the output state
+            var gameState = GameState(UUID.randomUUID(), playerANickname, me, opponent)
+
+            val txCommand = Command(GameContract.Commands.Create(), gameState.participants.map { it.owningKey })
+            val txBuilder = TransactionBuilder(notary)
+                    .addOutputState(gameState, GameContract.GAME_CONTRACT_ID)
+                    .addCommand(txCommand)
+
+            // Stage 2.
+            progressTracker.currentStep = SIGNING_TRANSACTION
+            // Sign the transaction.
+            val signedTx = serviceHub.signInitialTransaction(txBuilder)
+
+            //Stage 3.
+            progressTracker.currentStep = GATHERING_SIGS
+            val fullySignedTx = subFlow(CollectSignaturesFlow(signedTx, setOf(session), GATHERING_SIGS.childProgressTracker()))
+
+            // Stage 4.
+            progressTracker.currentStep = FINALISING_TRANSACTION
+            // Notarise and record the transaction in both parties' vaults.
+            return subFlow(FinalityFlow(fullySignedTx, FINALISING_TRANSACTION.childProgressTracker()))
+        }
+    }
+
+    @InitiatedBy(CreateGameFlow.Initiator::class)
+    class Acceptor(val otherPartyFlow: FlowSession) : FlowLogic<SignedTransaction>() {
+        object SIGNING_TRANSACTION : ProgressTracker.Step("Signing transaction with our private key.")
+
+        companion object {
+            fun tracker() = ProgressTracker(
+                    SIGNING_TRANSACTION
+            )
+        }
+
+        override val progressTracker = tracker()
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+            progressTracker.currentStep = SIGNING_TRANSACTION
+
+            val signTransactionFlow = object : SignTransactionFlow(otherPartyFlow) {
+                override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                    val outputGame = stx.tx.outputsOfType<GameState>().single()
+                }
+            }
+
+            return subFlow(signTransactionFlow)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a "create game" flow which initiates a transaction between 2 parties  (players). The GameState & GameContract have been introduced. When a new game is created, the corresponding state is instantiated which should be signed by both parties and sent to notary for verification.

The `POST create-game` endpoint has been enhanced in order to initiate the flow and return the result of the transaction. The result is logged on the UI (signatures console) and the appropriate setup takes place